### PR TITLE
Fix: Code select on Firefox adding unwanted spaces

### DIFF
--- a/Javascript/Sélectionner contenu d'un code.js
+++ b/Javascript/Sélectionner contenu d'un code.js
@@ -15,7 +15,7 @@ $.getScript('https://cdn.jsdelivr.net/clipboard.js/1.5.16/clipboard.min.js', fun
   $(function() {
     $('code').closest('.codebox').attr('id','codeBox');
     
-    var a = $('.codebox dt').not('.spoiler > dt, .hidecode > dt'),
+    var a = $('.codebox:not(.spoiler, .hidecode) dd'),
         i = 0,
         j = a.length;
  
@@ -23,7 +23,7 @@ $.getScript('https://cdn.jsdelivr.net/clipboard.js/1.5.16/clipboard.min.js', fun
       $('head').append('<style type="text/css">.fae_copy-code{float:right;cursor:pointer;}.fae_copy-code:hover{text-decoration:underline}</style>');
  
       for (; i < j; i++) {
-        a[i].insertAdjacentHTML('beforeend', '<div class="copyCode">' + fae_copyCode.copy + '</div>');
+        a[i].insertAdjacentHTML('afterbegin', '<div class="copyCode">' + fae_copyCode.copy + '</div>');
       }
  
       new Clipboard('.copyCode',{


### PR DESCRIPTION
Un bug apparemment spécifique à Firefox rajoute des espaces dans le code copié via le bouton inséré par le script. Le correctif vise à régler le problème sans nuire au fonctionnement général.

- cf https://github.com/zenorocha/clipboard.js/issues/382
- cf le serveur Discord de la Piscine : [Espaces qui s'incrustent dans les codages LS](https://discord.com/channels/982456035342164028/1279076070104236044)